### PR TITLE
Wip/configurable safety multipliers (#146)

### DIFF
--- a/bin/oref0-determine-basal.js
+++ b/bin/oref0-determine-basal.js
@@ -152,9 +152,9 @@ if (!module.parent) {
     console.error(JSON.stringify(currenttemp));
     console.error(JSON.stringify(profile));
 
-    var setTempBasal = require('oref0/lib/basal-set-temp');
+    var tempBasalFunctions = require('oref0/lib/basal-set-temp');
 
-    rT = determinebasal.determine_basal(glucose_status, currenttemp, iob_data, profile, autosens_data, meal_data, setTempBasal);
+    rT = determinebasal.determine_basal(glucose_status, currenttemp, iob_data, profile, autosens_data, meal_data, tempBasalFunctions);
 
     if(typeof rT.error === 'undefined') {
         console.log(JSON.stringify(rT));

--- a/bin/oref0-get-profile.js
+++ b/bin/oref0-get-profile.js
@@ -21,13 +21,49 @@ function usage ( ) {
         console.log('usage: ', process.argv.slice(0, 2), '<pump_settings.json> <bg_targets.json> <insulin_sensitivities.json> <basal_profile.json> [<max_iob.json>] [<carb_ratios.json>] [<temptargets.json>]');
 }
 
+function exportDefaults () {
+	var defaults = generate.defaults();
+	console.log(JSON.stringify(defaults, null, '\t'));
+}
+
+function updatePreferences (prefs) {
+	var defaults = generate.defaults();
+	
+	// check for any keys missing from current prefs and add from defaults
+	
+    for (var pref in defaults) {
+      if (defaults.hasOwnProperty(pref) && !prefs.hasOwnProperty(pref)) {
+        prefs[pref] = defaults[pref];
+      }
+    }
+
+	console.log(JSON.stringify(prefs, null, '\t'));
+}
+
 if (!module.parent) {
     
-    var pumpsettings_input = process.argv.slice(2, 3).pop()
+    var cwd = process.cwd()
+        
+    var pumpsettings_input = process.argv.slice(2, 3).pop();
+
+    if (pumpsettings_input !== undefined && pumpsettings_input.indexOf('export-defaults') > 0) {
+      exportDefaults();
+      process.exit(0);
+    }
+
+    if (pumpsettings_input !== undefined && pumpsettings_input.indexOf('update-preferences') > 0) {
+      var prefs_input = process.argv.slice(3, 4).pop();
+	  if (!prefs_input) { console.error('usage: ', process.argv.slice(0, 2), '<preferences.json>'); process.exit(0); }
+      var prefs = require(cwd + '/' + prefs_input);
+      updatePreferences(prefs);
+      process.exit(0);
+    }
+
     if ([null, '--help', '-h', 'help'].indexOf(pumpsettings_input) > 0) {
       usage( );
-      process.exit(0)
+      process.exit(0);
     }
+    
     var bgtargets_input = process.argv.slice(3, 4).pop()
     var isf_input = process.argv.slice(4, 5).pop()
     var basalprofile_input = process.argv.slice(5, 6).pop()
@@ -40,7 +76,6 @@ if (!module.parent) {
         process.exit(1);
     }
     
-    var cwd = process.cwd()
     var pumpsettings_data = require(cwd + '/' + pumpsettings_input);
     var bgtargets_data = require(cwd + '/' + bgtargets_input);
     if (bgtargets_data.units !== 'mg/dL') {

--- a/lib/basal-set-temp.js
+++ b/lib/basal-set-temp.js
@@ -1,5 +1,24 @@
-var setTempBasal = function (rate, duration, profile, rT, currenttemp) {
-    var maxSafeBasal = Math.min(profile.max_basal, 3 * profile.max_daily_basal, 4 * profile.current_basal);
+'use strict';
+
+function reason(rT, msg) {
+  rT.reason = (rT.reason ? rT.reason + '. ' : '') + msg;
+  console.error(msg);
+}
+
+var tempBasalFunctions = {};
+
+tempBasalFunctions.getMaxSafeBasal = function getMaxSafeBasal(profile) {
+
+	var max_daily_safety_multiplier = (isNaN(profile.max_daily_safety_multiplier) || profile.max_daily_safety_multiplier == null) ? 3 : profile.max_daily_safety_multiplier;
+	var current_basal_safety_multiplier = (isNaN(profile.current_basal_safety_multiplier) || profile.current_basal_safety_multiplier == null) ? 4 : profile.current_basal_safety_multiplier;
+	
+	return Math.min(profile.max_basal, max_daily_safety_multiplier * profile.max_daily_basal, current_basal_safety_multiplier * profile.current_basal);
+};
+
+tempBasalFunctions.setTempBasal = function setTempBasal(rate, duration, profile, rT, currenttemp) {
+    //var maxSafeBasal = Math.min(profile.max_basal, 3 * profile.max_daily_basal, 4 * profile.current_basal);
+    
+    var maxSafeBasal = tempBasalFunctions.getMaxSafeBasal(profile);
     
     if (rate < 0) { 
         rate = 0; 
@@ -38,9 +57,4 @@ var setTempBasal = function (rate, duration, profile, rT, currenttemp) {
     }
 };
 
-function reason(rT, msg) {
-  rT.reason = (rT.reason ? rT.reason + '. ' : '') + msg;
-  console.error(msg);
-}
-
-module.exports = setTempBasal;
+module.exports = tempBasalFunctions;

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -12,7 +12,10 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-var determine_basal = function determine_basal(glucose_status, currenttemp, iob_data, profile, autosens_data, meal_data, setTempBasal) {
+
+//require('../basal-set-temp');
+
+var determine_basal = function determine_basal(glucose_status, currenttemp, iob_data, profile, autosens_data, meal_data, tempBasalFunctions) {
     var rT = { //short for requestedTemp
     };
 
@@ -35,7 +38,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         rT.reason = "CGM is calibrating or in ??? state";
         if (basal < currenttemp.rate + 0.1) { // high temp is running
             rT.reason += "; setting current basal of " + basal + " as temp";
-            return setTempBasal(basal, 30, profile, rT, currenttemp);
+            return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
         } else { //do nothing.
             rT.reason += ", temp " + currenttemp.rate + " <~ current basal " + basal + "U/hr";
             return rT;
@@ -263,7 +266,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         rT.reason += "BG " + bg + "<" + threshold;
         if ((glucose_status.delta <= 0 && minDelta <= 0) || (glucose_status.delta < expectedDelta && minDelta < expectedDelta) || bg < 60 ) {
             // BG is still falling / rising slower than predicted
-            return setTempBasal(0, 30, profile, rT, currenttemp);
+            return tempBasalFunctions.setTempBasal(0, 30, profile, rT, currenttemp);
         }
         if (glucose_status.delta > minDelta) {
             rT.reason += ", delta " + glucose_status.delta + ">0";
@@ -275,7 +278,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             return rT;
         } else {
             rT.reason += "; setting current basal of " + basal + " as temp";
-            return setTempBasal(basal, 30, profile, rT, currenttemp);
+            return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
         }
     }
 
@@ -296,7 +299,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                     return rT;
                 } else {
                     rT.reason += "; setting current basal of " + basal + " as temp";
-                    return setTempBasal(basal, 30, profile, rT, currenttemp);
+                    return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
                 }
             }
         //}
@@ -311,7 +314,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                     return rT;
                 } else {
                     rT.reason += "; setting current basal of " + basal + " as temp";
-                    return setTempBasal(basal, 30, profile, rT, currenttemp);
+                    return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
                 }
             } else {
                 // calculate 30m low-temp required to get projected BG up to target
@@ -332,14 +335,14 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 var insulinScheduled = currenttemp.duration * (currenttemp.rate - basal) / 60;
                 if (insulinScheduled < insulinReq - 0.2) { // if current temp would deliver >0.2U less than the required insulin, raise the rate
                     rT.reason += ", "+currenttemp.duration + "m@" + (currenttemp.rate - basal).toFixed(3) + " = " + insulinScheduled.toFixed(3) + " < req " + insulinReq + "-0.2U";
-                    return setTempBasal(rate, 30, profile, rT, currenttemp);
+                    return tempBasalFunctions.setTempBasal(rate, 30, profile, rT, currenttemp);
                 }
                 if (typeof currenttemp.rate !== 'undefined' && (currenttemp.duration > 5 && rate > currenttemp.rate - 0.1)) {
                     rT.reason += ", temp " + currenttemp.rate + " ~< req " + rate + "U/hr";
                     return rT;
                 } else {
                     rT.reason += ", setting " + rate + "U/hr";
-                    return setTempBasal(rate, 30, profile, rT, currenttemp);
+                    return tempBasalFunctions.setTempBasal(rate, 30, profile, rT, currenttemp);
                 }
             }
         }
@@ -357,7 +360,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             return rT;
         } else {
             rT.reason += "; setting current basal of " + basal + " as temp";
-            return setTempBasal(basal, 30, profile, rT, currenttemp);
+            return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
         }
     }
 
@@ -368,7 +371,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             return rT;
         } else {
             rT.reason += "; setting current basal of " + basal + " as temp";
-            return setTempBasal(basal, 30, profile, rT, currenttemp);
+            return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
         }
     }
 
@@ -385,7 +388,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             return rT;
         } else {
             rT.reason += "; setting current basal of " + basal + " as temp";
-            return setTempBasal(basal, 30, profile, rT, currenttemp);
+            return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
         }
     } else { // otherwise, calculate 30m high-temp required to get projected BG down to target
 
@@ -407,7 +410,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         var rate = basal + (2 * insulinReq);
         rate = Math.round( rate * 1000 ) / 1000;
 
-        var maxSafeBasal = Math.min(profile.max_basal, 3 * profile.max_daily_basal, 4 * basal);
+//        var maxSafeBasal = Math.min(profile.max_basal, 3 * profile.max_daily_basal, 4 * basal);
+        
+        var maxSafeBasal = tempBasalFunctions.getMaxSafeBasal(profile);
+        
         if (rate > maxSafeBasal) {
             rT.reason += "adj. req. rate:"+rate.toFixed(1) +" to maxSafeBasal:"+maxSafeBasal.toFixed(1)+", ";
             rate = maxSafeBasal.toFixed(1);
@@ -416,12 +422,12 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         var insulinScheduled = currenttemp.duration * (currenttemp.rate - basal) / 60;
         if (insulinScheduled > insulinReq + 0.1) { // if current temp would deliver >0.1U more than the required insulin, lower the rate
             rT.reason += currenttemp.duration + "m@" + (currenttemp.rate - basal).toFixed(3) + " = " + insulinScheduled.toFixed(3) + " > req " + insulinReq + "+0.1U";
-            return setTempBasal(rate, 30, profile, rT, currenttemp);
+            return tempBasalFunctions.setTempBasal(rate, 30, profile, rT, currenttemp);
         }
 
         if (typeof currenttemp.duration == 'undefined' || currenttemp.duration == 0) { // no temp is set
             rT.reason += "no temp, setting " + rate + "U/hr";
-            return setTempBasal(rate, 30, profile, rT, currenttemp);
+            return tempBasalFunctions.setTempBasal(rate, 30, profile, rT, currenttemp);
         }
 
         if (currenttemp.duration > 5 && rate < currenttemp.rate + 0.1) { // if required temp <~ existing temp basal
@@ -431,7 +437,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
         // required temp > existing temp basal
         rT.reason += "temp " + currenttemp.rate + "<" + rate + "U/hr";
-        return setTempBasal(rate, 30, profile, rT, currenttemp);
+        return tempBasalFunctions.setTempBasal(rate, 30, profile, rT, currenttemp);
     }
 
 };

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -9,12 +9,22 @@ function defaults ( ) {
           max_iob: 0 // if max_iob is not provided, never give more insulin than the pump would have
         // , dia: pumpsettings_data.insulin_action_curve        
         , type: "current"
+    	,max_daily_safety_multiplier: 3
+		,current_basal_safety_multiplier: 4
     };
     return profile;
 }
 
 function generate (inputs, opts) {
   var profile = opts && opts.type ? opts : defaults( );
+
+  // check if inputs has overrides for any of the default prefs
+  // and apply if applicable
+  for (var pref in profile) {
+    if (inputs.hasOwnProperty(pref)) {
+    profile[pref] = inputs[pref];
+    }
+  }
 
   var pumpsettings_data = inputs.settings;
   if (inputs.settings.insulin_action_curve > 1) {
@@ -24,9 +34,6 @@ function generate (inputs, opts) {
     return -1;
   }
 
-  if (inputs.max_iob) {
-    profile.max_iob = inputs.max_iob;
-  }
   profile.skip_neutral_temps = inputs.skip_neutral_temps;
 
   profile.current_basal = basal.basalLookup(inputs.basals);

--- a/tests/determine-basal.test.js
+++ b/tests/determine-basal.test.js
@@ -6,7 +6,7 @@ var should = require('should');
 
 describe('determine-basal', function ( ) {
     var determine_basal = require('../lib/determine-basal/determine-basal');
-    var setTempBasal = require('../lib/basal-set-temp');
+    var tempBasalFunctions = require('../lib/basal-set-temp');
 
    //function determine_basal(glucose_status, currenttemp, iob_data, profile)
 
@@ -19,19 +19,19 @@ describe('determine-basal', function ( ) {
 
     it('should cancel any temp when in range w/o IOB', function () {
         var currenttemp = {"duration":30,"rate":0,"temp":"absolute"};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         //output.rate.should.equal(0);
         //output.duration.should.equal(0);
         output.rate.should.equal(0.9);
         output.duration.should.equal(30);
         output.reason.should.match(/in range.*/);
     });
-    
+
 
     // low glucose suspend test cases
     it('should temp to 0 when low w/o IOB', function () {
         var glucose_status = {"delta":-5,"glucose":75,"avgdelta":-5};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0);
         output.duration.should.equal(30);
         output.reason.should.match(/BG 75<80/);
@@ -40,7 +40,7 @@ describe('determine-basal', function ( ) {
     it('should not extend temp to 0 when >20m left', function () {
         var currenttemp = {"duration":27,"rate":0,"temp":"absolute"};
         var glucose_status = {"delta":-5,"glucose":75,"avgdelta":-5};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         //console.log(output);
         (typeof output.rate).should.equal('undefined');
         (typeof output.duration).should.equal('undefined');
@@ -48,7 +48,7 @@ describe('determine-basal', function ( ) {
 
     it('should do nothing when low and rising w/o IOB', function () {
         var glucose_status = {"delta":5,"glucose":75,"avgdelta":5};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0.9);
         output.duration.should.equal(30);
         output.reason.should.match(/75<80.*setting current basal/);
@@ -57,7 +57,7 @@ describe('determine-basal', function ( ) {
     it('should do nothing when low and rising w/ negative IOB', function () {
         var glucose_status = {"delta":5,"glucose":75,"avgdelta":5};
         var iob_data = {"iob":-1,"activity":-0.01,"bolussnooze":0};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0.9);
         output.duration.should.equal(30);
         output.reason.should.match(/75<80.*setting current basal/);
@@ -65,7 +65,7 @@ describe('determine-basal', function ( ) {
 
     it('should do nothing on large uptick even if avgdelta is still negative', function () {
         var glucose_status = {"delta":4,"glucose":75,"avgdelta":-2};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0.9);
         output.duration.should.equal(30);
         output.reason.should.match(/BG 75<80/);
@@ -74,7 +74,7 @@ describe('determine-basal', function ( ) {
     it('should temp to 0 when rising slower than BGI', function () {
         var glucose_status = {"delta":1,"glucose":75,"avgdelta":1};
         var iob_data = {"iob":-1,"activity":-0.01,"bolussnooze":0};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0);
         output.duration.should.equal(30);
         output.reason.should.match(/BG 75<80/);
@@ -83,7 +83,7 @@ describe('determine-basal', function ( ) {
     it('should temp to 0 when low and falling, regardless of BGI', function () {
         var glucose_status = {"delta":-1,"glucose":75,"avgdelta":-1};
         var iob_data = {"iob":1,"activity":0.01,"bolussnooze":0.5};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0);
         output.duration.should.equal(30);
         output.reason.should.match(/BG 75<80/);
@@ -93,7 +93,7 @@ describe('determine-basal', function ( ) {
         var currenttemp = {"duration":20,"rate":2,"temp":"absolute"};
         var glucose_status = {"delta":5,"glucose":75,"avgdelta":5};
         var iob_data = {"iob":-1,"activity":-0.01,"bolussnooze":0};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         //output.rate.should.equal(0);
         //output.duration.should.equal(0);
         output.rate.should.equal(0.9);
@@ -105,7 +105,7 @@ describe('determine-basal', function ( ) {
         var currenttemp = {"duration":20,"rate":0,"temp":"absolute"};
         var glucose_status = {"delta":5,"glucose":75,"avgdelta":5};
         var iob_data = {"iob":-1,"activity":-0.01,"bolussnooze":0};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         //console.log(output);
         output.rate.should.equal(0.9);
         output.duration.should.equal(30);
@@ -115,7 +115,7 @@ describe('determine-basal', function ( ) {
     it('should high-temp when > 80-ish and rising w/ lots of negative IOB', function () {
         var glucose_status = {"delta":5,"glucose":85,"avgdelta":5};
         var iob_data = {"iob":-1,"activity":-0.01,"bolussnooze":0};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.be.above(1);
         output.duration.should.equal(30);
         output.reason.should.match(/no temp, setting/);
@@ -124,7 +124,7 @@ describe('determine-basal', function ( ) {
     it('should high-temp when > 180-ish and rising but not more then maxSafeBasal', function () {
         var glucose_status = {"delta":5,"glucose":185,"avgdelta":5};
         var iob_data = {"iob":0,"activity":-0.01,"bolussnooze":0};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.reason.should.match(/.*, adj. req. rate:.* to maxSafeBasal:.*, no temp, setting/);
     });
     
@@ -132,7 +132,7 @@ describe('determine-basal', function ( ) {
         var glucose_status = {"delta":5,"glucose":145,"avgdelta":5};
         var currenttemp = {"duration":160,"rate":1.9,"temp":"absolute"};
         var iob_data = {"iob":0,"activity":-0.01,"bolussnooze":0};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.duration.should.equal(30);
         output.reason.should.match(/.*m.* = .* > req .*/);
     });
@@ -141,7 +141,7 @@ describe('determine-basal', function ( ) {
         var glucose_status = {"delta":5,"glucose":145,"avgdelta":5};
         var currenttemp = {"duration":30,"rate":3.5,"temp":"absolute"};
         var iob_data = {"iob":0,"activity":-0.01,"bolussnooze":0};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         //console.log(output);
         (typeof output.rate).should.equal('undefined');
         (typeof output.duration).should.equal('undefined');
@@ -152,7 +152,7 @@ describe('determine-basal', function ( ) {
         var glucose_status = {"delta":5,"glucose":145,"avgdelta":5};
         var currenttemp = {"duration":30,"rate":1.1,"temp":"absolute"};
         var iob_data = {"iob":0,"activity":-0.01,"bolussnooze":0};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.duration.should.equal(30);
         output.reason.should.match(/Eventual BG .*>.*, temp/);
     });
@@ -160,7 +160,7 @@ describe('determine-basal', function ( ) {
     it('should stop high-temp when iob is near max_iob.', function () {
         var glucose_status = {"delta":5,"glucose":485,"avgdelta":5};
         var iob_data = {"iob":3.5,"activity":0.05,"bolussnooze":0};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0.9);
         output.duration.should.equal(30);
         output.reason.should.match(/basaliob .* > max_iob .*/);
@@ -169,7 +169,7 @@ describe('determine-basal', function ( ) {
     it('should temp to 0 when LOW w/ positive IOB', function () {
         var glucose_status = {"delta":0,"glucose":39,"avgdelta":0};
         var iob_data = {"iob":1,"activity":0.01,"bolussnooze":0.5};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0);
         output.duration.should.equal(30);
         output.reason.should.match(/BG 39<80/);
@@ -178,7 +178,7 @@ describe('determine-basal', function ( ) {
     it('should temp to 0 when LOW w/ negative IOB', function () {
         var glucose_status = {"delta":0,"glucose":39,"avgdelta":0};
         var iob_data = {"iob":-2.5,"activity":-0.03,"bolussnooze":0};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0);
         output.duration.should.equal(30);
         output.reason.should.match(/BG 39<80/);
@@ -187,7 +187,7 @@ describe('determine-basal', function ( ) {
     it('should temp to 0 when LOW w/ no IOB', function () {
         var glucose_status = {"delta":0,"glucose":39,"avgdelta":0};
         var iob_data = {"iob":0,"activity":0,"bolussnooze":0};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0);
         output.duration.should.equal(30);
         output.reason.should.match(/BG 39<80/);
@@ -199,7 +199,7 @@ describe('determine-basal', function ( ) {
 
     it('should low-temp when eventualBG < min_bg', function () {
         var glucose_status = {"delta":-3,"glucose":110,"avgdelta":-1};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         //console.log(output);
         output.rate.should.be.below(0.8);
         output.duration.should.equal(30);
@@ -209,7 +209,7 @@ describe('determine-basal', function ( ) {
     it('should low-temp when eventualBG < min_bg with delta > exp. delta', function () {
         var glucose_status = {"delta":-5,"glucose":115,"avgdelta":-6};
         var iob_data = {"iob":2,"activity":0.05,"bolussnooze":0};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         //console.log(output);
         output.rate.should.be.below(0.2);
         output.duration.should.equal(30);
@@ -219,7 +219,7 @@ describe('determine-basal', function ( ) {
     it('should low-temp when eventualBG < min_bg with delta > exp. delta', function () {
         var glucose_status = {"delta":-2,"glucose":156,"avgdelta":-1.33};
         var iob_data = {"iob":3.51,"activity":0.06,"bolussnooze":0.08};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         //console.log(output);
         output.rate.should.be.below(0.8);
         output.duration.should.equal(30);
@@ -229,7 +229,7 @@ describe('determine-basal', function ( ) {
     it('should low-temp much less when eventualBG < min_bg with delta barely negative', function () {
         var glucose_status = {"delta":-1,"glucose":115,"avgdelta":-1};
         var iob_data = {"iob":2,"activity":0.05,"bolussnooze":0};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.be.above(0.3);
         output.rate.should.be.below(0.8);
         output.duration.should.equal(30);
@@ -239,7 +239,7 @@ describe('determine-basal', function ( ) {
     it('should do nothing when eventualBG < min_bg but appropriate low temp in progress', function () {
         var glucose_status = {"delta":-1,"glucose":110,"avgdelta":-1};
         var currenttemp = {"duration":20,"rate":0.25,"temp":"absolute"};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         (typeof output.rate).should.equal('undefined');
         (typeof output.duration).should.equal('undefined');
         output.reason.should.match(/Eventual BG .*<110, temp .*/);
@@ -249,7 +249,7 @@ describe('determine-basal', function ( ) {
         var currenttemp = {"duration":20,"rate":0.5,"temp":"absolute"};
         var glucose_status = {"delta":3,"glucose":85,"avgdelta":3};
         var iob_data = {"iob":-0.7,"activity":-0.01,"bolussnooze":0};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0.9);
         output.duration.should.equal(30);
         //output.rate.should.equal(0);
@@ -261,7 +261,7 @@ describe('determine-basal', function ( ) {
         var currenttemp = {"duration":20,"rate":0.5,"temp":"absolute"};
         var glucose_status = {"delta":3,"glucose":85,"avgdelta":3};
         var iob_data = {"iob":-0.7,"activity":-0.01,"bolussnooze":0};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0.9);
         output.duration.should.equal(30);
     });
@@ -270,7 +270,7 @@ describe('determine-basal', function ( ) {
         var currenttemp = {"duration":0,"rate":0.5,"temp":"absolute"};
         var glucose_status = {"delta":3,"glucose":85,"avgdelta":3};
         var iob_data = {"iob":-0.7,"activity":-0.01,"bolussnooze":0};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         //(typeof output.rate).should.equal('undefined');
         //(typeof output.duration).should.equal('undefined');
         output.rate.should.equal(0.9);
@@ -282,7 +282,7 @@ describe('determine-basal', function ( ) {
     it('should low-temp when low and rising slower than BGI', function () {
         var glucose_status = {"delta":1,"glucose":85,"avgdelta":1};
         var iob_data = {"iob":-0.5,"activity":-0.01,"bolussnooze":0};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.be.below(0.8);
         output.duration.should.equal(30);
         output.reason.should.match(/setting/);
@@ -292,7 +292,7 @@ describe('determine-basal', function ( ) {
 
     it('should high-temp when eventualBG > max_bg', function () {
         var glucose_status = {"delta":+3,"glucose":120,"avgdelta":+1};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.be.above(1);
         output.duration.should.equal(30);
         output.reason.should.match(/Eventual BG .*>=120/);
@@ -302,7 +302,7 @@ describe('determine-basal', function ( ) {
         var currenttemp = {"duration":20,"rate":2,"temp":"absolute"};
         var glucose_status = {"delta":-5,"glucose":175,"avgdelta":-5};
         var iob_data = {"iob":1,"activity":0.01,"bolussnooze":0};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0.9);
         output.duration.should.equal(30);
         //output.reason.should.match(/.*; cancel/);
@@ -315,7 +315,7 @@ describe('determine-basal', function ( ) {
         var currenttemp = {"duration":20,"rate":2,"temp":"absolute"};
         var glucose_status = {"delta":-5,"glucose":175,"avgdelta":-4};
         var iob_data = {"iob":1,"activity":0.01,"bolussnooze":0};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0.9);
         output.duration.should.equal(30);
         output.reason.should.match(/Eventual BG.*>.*but.*Delta.*< Exp.*/);
@@ -325,7 +325,7 @@ describe('determine-basal', function ( ) {
         var currenttemp = {"duration":0,"rate":0,"temp":"absolute"};
         var glucose_status = {"delta":-5,"glucose":175,"avgdelta":-4};
         var iob_data = {"iob":1,"activity":0.01,"bolussnooze":0};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         //(typeof output.rate).should.equal('undefined');
         //(typeof output.duration).should.equal('undefined');
         output.rate.should.equal(0.9);
@@ -336,7 +336,7 @@ describe('determine-basal', function ( ) {
     it('should high-temp when high and falling slower than BGI', function () {
         var glucose_status = {"delta":-1,"glucose":175,"avgdelta":-1};
         var iob_data = {"iob":1,"activity":0.01,"bolussnooze":0};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.be.above(1);
         output.duration.should.equal(30);
         output.reason.should.match(/no temp, setting/);
@@ -345,7 +345,7 @@ describe('determine-basal', function ( ) {
     it('should high-temp when high and falling slowly with low insulin activity', function () {
         var glucose_status = {"delta":-1,"glucose":300,"avgdelta":-1};
         var iob_data = {"iob":0.5,"activity":0.005,"bolussnooze":0};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.be.above(2.5);
         output.duration.should.equal(30);
         output.reason.should.match(/no temp, setting/);
@@ -354,7 +354,7 @@ describe('determine-basal', function ( ) {
     it('should set lower high-temp when high and falling almost fast enough with low insulin activity', function () {
         var glucose_status = {"delta":-8,"glucose":300,"avgdelta":-5};
         var iob_data = {"iob":0.5,"activity":0.005,"bolussnooze":0};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.be.above(1);
         output.rate.should.be.below(2);
         output.duration.should.equal(30);
@@ -365,7 +365,7 @@ describe('determine-basal', function ( ) {
         var glucose_status = {"delta":-8,"glucose":300,"avgdelta":-5};
         var iob_data = {"iob":0.5,"activity":0.005,"bolussnooze":0};
         var currenttemp = {"duration":30,"rate":2.5,"temp":"absolute"};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.be.above(1);
         output.rate.should.be.below(2);
         output.duration.should.equal(30);
@@ -379,7 +379,7 @@ describe('determine-basal', function ( ) {
 
     it('should let low-temp run when bg < 30 (Dexcom is in ???)', function () {
         var currenttemp = {"duration":30,"rate":0,"temp":"absolute"};
-        var output = determine_basal({glucose:18},currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal({glucose:18},currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         //console.log(output);
         (typeof output.rate).should.equal('undefined');
         output.reason.should.match(/CGM is calibrating/);
@@ -387,30 +387,30 @@ describe('determine-basal', function ( ) {
 
     it('should cancel high-temp when bg < 30 (Dexcom is in ???)', function () {
         var currenttemp = {"duration":30,"rate":2,"temp":"absolute"};
-        var output = determine_basal({glucose:18},currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal({glucose:18},currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         //console.log(output);
         output.rate.should.be.below(1);
         output.reason.should.match(/CGM is calibrating/);
     });  
 
     it('profile should contain min_bg,max_bg or target_bg', function () {
-      var result = determine_basal({glucose:100},undefined, undefined, {"current_basal":0.0}, undefined, meal_data, setTempBasal);
+      var result = determine_basal({glucose:100},undefined, undefined, {"current_basal":0.0}, undefined, meal_data, tempBasalFunctions);
       result.error.should.equal('Error: could not determine target_bg');
     });
 
     it('iob_data should not be undefined', function () {
-      var result = determine_basal({glucose:100},undefined, undefined, {"current_basal":0.0, "target_bg":100}, undefined, meal_data, setTempBasal);
+      var result = determine_basal({glucose:100},undefined, undefined, {"current_basal":0.0, "target_bg":100}, undefined, meal_data, tempBasalFunctions);
       result.error.should.equal('Error: iob_data undefined');
     }); 
 
     it('iob_data should contain activity, iob, bolussnooze', function () {
-      var result = determine_basal({glucose:100}, undefined,{"activity":0}, {"current_basal":0.0, "target_bg":100}, undefined, meal_data, setTempBasal);
+      var result = determine_basal({glucose:100}, undefined,{"activity":0}, {"current_basal":0.0, "target_bg":100}, undefined, meal_data, tempBasalFunctions);
       result.error.should.equal('Error: iob_data missing some property');
     });  
 
 /*
     it('should return error eventualBG if something went wrong', function () {
-      var result = determine_basal({glucose:100}, undefined,{"activity":0, "iob":0,"bolussnooze":0}, {"current_basal":0.0, "target_bg":100, "sens":NaN}, undefined, meal_data, setTempBasal);
+      var result = determine_basal({glucose:100}, undefined,{"activity":0, "iob":0,"bolussnooze":0}, {"current_basal":0.0, "target_bg":100, "sens":NaN}, undefined, meal_data, tempBasalFunctions);
       result.error.should.equal('Error: could not calculate eventualBG');
     });
 */
@@ -421,7 +421,7 @@ describe('determine-basal', function ( ) {
         var glucose_status = {"delta":1,"glucose":80,"avgdelta":1};
         var iob_data = {"iob":0.5,"activity":-0.01,"bolussnooze":1,"basaliob":-0.5};
         var meal_data = {"carbs":20,"boluses":1, "mealCOB":20};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0.9);
         output.duration.should.equal(30);
     });
@@ -432,7 +432,7 @@ describe('determine-basal', function ( ) {
         var meal_data = {"carbs":65,"boluses":4, "mealCOB":65};
         var currenttemp = {"duration":29,"rate":1.3,"temp":"absolute"};
         var profile = {"max_iob":3,"type":"current","dia":3,"current_basal":1.3,"max_daily_basal":1.3,"max_basal":3.5,"min_bg":105,"max_bg ":105,"sens":40,"carb_ratio":10}
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         //console.log(output);
         (typeof output.rate).should.equal('undefined');
         (typeof output.duration).should.equal('undefined');
@@ -442,7 +442,7 @@ describe('determine-basal', function ( ) {
         var glucose_status = {"delta":-1,"glucose":80,"avgdelta":1};
         var iob_data = {"iob":0.5,"activity":-0.01,"bolussnooze":1,"basaliob":-0.5};
         var currenttemp = {"duration":20,"rate":2,"temp":"absolute"};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         //console.log(output);
         //output.rate.should.equal(0);
         //output.duration.should.equal(0);
@@ -454,7 +454,7 @@ describe('determine-basal', function ( ) {
         var glucose_status = {"delta":1,"glucose":80,"avgdelta":1};
         var iob_data = {"iob":0.5,"activity":-0.01,"bolussnooze":1,"basaliob":-0.5};
         var currenttemp = {"duration":20,"rate":0,"temp":"absolute"};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         //console.log(output);
         output.rate.should.equal(0.9);
         output.duration.should.equal(30);
@@ -468,7 +468,7 @@ describe('determine-basal', function ( ) {
         var glucose_status = {"delta":10,"glucose":120,"avgdelta":10};
         var iob_data = {"iob":0.4,"activity":0,"bolussnooze":0.7,"basaliob":-0.3};
         var meal_data = {"carbs":20,"boluses":1, "mealCOB":20};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         console.log(output);
         output.rate.should.be.above(1.8);
         output.duration.should.equal(30);
@@ -480,7 +480,7 @@ describe('determine-basal', function ( ) {
         var iob_data = {"iob":0.5,"activity":0.01,"bolussnooze":0.6,"basaliob":-0.1};
         var meal_data = {"carbs":20,"boluses":1, "mealCOB":20};
         var currenttemp = {"duration":10,"rate":2,"temp":"absolute"};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         console.log(output);
         output.rate.should.be.above(2.2);
         output.duration.should.equal(30);
@@ -492,7 +492,7 @@ describe('determine-basal', function ( ) {
         var iob_data = {"iob":0.9,"activity":0.02,"bolussnooze":0.5,"basaliob":0.4};
         var meal_data = {"carbs":20,"boluses":1, "mealCOB":20};
         var currenttemp = {"duration":30,"rate":2.5,"temp":"absolute"};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.be.below(1.5);
     });
 
@@ -501,7 +501,7 @@ describe('determine-basal', function ( ) {
         var glucose_status = {"delta":4,"glucose":120,"avgdelta":4};
         var iob_data = {"iob":6,"activity":0,"bolussnooze":6,"basaliob":0,"hightempinsulin":0};
         var meal_data = {"carbs":120,"boluses":6, "mealCOB":120};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         console.log(output);
         output.rate.should.be.above(1);
         output.duration.should.equal(30);
@@ -512,7 +512,7 @@ describe('determine-basal', function ( ) {
         var glucose_status = {"delta":4,"glucose":140,"avgdelta":4};
         var iob_data = {"iob":6.5,"activity":0.01,"bolussnooze":5.5,"basaliob":1,"hightempinsulin":1};
         var meal_data = {"carbs":120,"boluses":6, "mealCOB":100};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         console.log(output);
         output.rate.should.be.above(1);
         output.duration.should.equal(30);
@@ -523,7 +523,7 @@ describe('determine-basal', function ( ) {
         var glucose_status = {"delta":4,"glucose":160,"avgdelta":4};
         var iob_data = {"iob":7.0,"activity":0.02,"bolussnooze":5.0,"basaliob":2,"hightempinsulin":2};
         var meal_data = {"carbs":120,"boluses":6, "mealCOB":80};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         console.log(output);
         output.rate.should.be.above(1);
         output.duration.should.equal(30);
@@ -534,7 +534,7 @@ describe('determine-basal', function ( ) {
         var glucose_status = {"delta":1,"glucose":160,"avgdelta":1};
         var iob_data = {"iob":7.0,"activity":0.02,"bolussnooze":5.0,"basaliob":2};
         var meal_data = {"carbs":120,"boluses":6, "mealCOB":80};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         console.log(output);
         //should.not.exist(output.rate);
         //should.not.exist(output.duration);
@@ -548,7 +548,7 @@ describe('determine-basal', function ( ) {
         var iob_data = {"iob":7.0,"activity":0.03,"bolussnooze":5.0,"basaliob":2};
         var meal_data = {"carbs":120,"boluses":6, "mealCOB":80};
         var currenttemp = {"duration":15,"rate":2.5,"temp":"absolute"};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0.9);
         output.duration.should.equal(30);
         //output.rate.should.equal(0);
@@ -559,7 +559,7 @@ describe('determine-basal', function ( ) {
         var glucose_status = {"delta":1,"glucose":160,"avgdelta":1};
         var iob_data = {"iob":7.0,"activity":0.02,"bolussnooze":4.0,"basaliob":3};
         var meal_data = {"carbs":120,"boluses":11, "mealCOB":80};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         console.log(output);
         output.rate.should.equal(0.9);
         output.duration.should.equal(30);
@@ -573,7 +573,7 @@ describe('determine-basal', function ( ) {
         var currenttemp = {"duration":3,"rate":3.5,"temp":"absolute"}
         var iob_data = {"iob":2.701,"activity":0.0107,"bolussnooze":0.866,"basaliob":1.013,"netbasalinsulin":1.1,"hightempinsulin":1.8}
         var profile_data = {"max_iob":3,"type":"current","dia":3,"current_basal":0.9,"max_daily_basal":1.3,"max_basal":3.5,"min_bg":105,"max_bg":105,"sens":40,"carb_ratio":10}
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         //console.log(output);
         //output.rate.should.equal(0.9);
         //output.duration.should.equal(30);
@@ -586,10 +586,40 @@ describe('determine-basal', function ( ) {
         //var glucose_status = {"delta":1,"glucose":160,"avgdelta":1};
         var iob_data = {"iob":0.5,"activity":0.001,"bolussnooze":0.0,"basaliob":0.5};
         var autosens_data = {"ratio":0.5};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, autosens_data, meal_data, setTempBasal);
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, autosens_data, meal_data, tempBasalFunctions);
         //console.log(output);
         output.rate.should.equal(0);
         output.duration.should.equal(30);
+    });
+
+    it('maxSafeBasal current_basal_safety_multiplier of 1 should cause the current rate to be set, even if higher is needed', function () {
+        var glucose_status = {"delta":5,"glucose":185,"avgdelta":5};
+        var iob_data = {"iob":0,"activity":-0.01,"bolussnooze":0};
+        profile.current_basal_safety_multiplier = 1;
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
+        output.rate.should.equal(0.9);
+        output.reason.should.match(/.*, adj. req. rate:.* to maxSafeBasal:.*, no temp, setting/);
+    });
+    
+    it('maxSafeBasal max_daily_safety_multiplier of 1 should cause the max daily rate to be set, even if higher is needed', function () {
+        var glucose_status = {"delta":5,"glucose":185,"avgdelta":5};
+        var iob_data = {"iob":0,"activity":-0.01,"bolussnooze":0};
+        profile.current_basal_safety_multiplier = null;
+        profile.max_daily_safety_multiplier = 1;
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
+        output.rate.should.equal(1.3);
+        output.reason.should.match(/.*, adj. req. rate:.* to maxSafeBasal:.*, no temp, setting/);
+    });
+
+    it('overriding maxSafeBasal multipliers to 10 should increase temp', function () {
+        var glucose_status = {"delta":5,"glucose":285,"avgdelta":5};
+        var iob_data = {"iob":0,"activity":-0.01,"bolussnooze":0};
+        profile.max_basal = 5;
+        profile.current_basal_safety_multiplier = 10;
+        profile.max_daily_safety_multiplier = 10;
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
+        output.rate.should.equal(5);
+        output.reason.should.match(/.*, adj. req. rate:.* to maxSafeBasal:.*, no temp, setting/);
     });
 
 });

--- a/tests/set-temp-basal.test.js
+++ b/tests/set-temp-basal.test.js
@@ -3,27 +3,27 @@
 require('should');
 
 
-describe('setTempBasal', function ( ) {
-    var setTempBasal = require('../lib/basal-set-temp');
+describe('tempBasalFunctions.setTempBasal', function ( ) {
+    var tempBasalFunctions = require('../lib/basal-set-temp');
 
-   //function setTempBasal(rate, duration, profile, requestedTemp)
+   //function tempBasalFunctions.setTempBasal(rate, duration, profile, requestedTemp)
 
     var profile = { "current_basal":0.8,"max_daily_basal":1.3,"max_basal":3.0 };
     var rt = {};
     it('should cancel temp', function () {
-        var requestedTemp = setTempBasal(0, 0, profile, rt);
+        var requestedTemp = tempBasalFunctions.setTempBasal(0, 0, profile, rt);
         requestedTemp.rate.should.equal(0);
         requestedTemp.duration.should.equal(0);
     });
 
     it('should set zero temp', function () {
-        var requestedTemp = setTempBasal(0, 30, profile, rt);
+        var requestedTemp = tempBasalFunctions.setTempBasal(0, 30, profile, rt);
         requestedTemp.rate.should.equal(0);
         requestedTemp.duration.should.equal(30);
     });
 
     it('should set high temp', function () {
-        var requestedTemp = setTempBasal(2, 30, profile, rt);
+        var requestedTemp = tempBasalFunctions.setTempBasal(2, 30, profile, rt);
         requestedTemp.rate.should.equal(2);
         requestedTemp.duration.should.equal(30);
     });
@@ -32,35 +32,50 @@ describe('setTempBasal', function ( ) {
         profile.skip_neutral_temps = true;
         var rt2 = {};
         var current = {duration: 10};
-        var requestedTemp = setTempBasal(0.8, 30, profile, rt2, current);
+        var requestedTemp = tempBasalFunctions.setTempBasal(0.8, 30, profile, rt2, current);
         requestedTemp.duration.should.equal(0);
-        var requestedTemp = setTempBasal(0.8, 30, profile, {});
+        var requestedTemp = tempBasalFunctions.setTempBasal(0.8, 30, profile, {});
         requestedTemp.reason.should.equal('Suggested rate is same as profile rate, no temp basal is active, doing nothing');
     });
 
     it('should limit high temp to max_basal', function () {
-        var requestedTemp = setTempBasal(4, 30, profile, rt);
+        var requestedTemp = tempBasalFunctions.setTempBasal(4, 30, profile, rt);
         requestedTemp.rate.should.equal(3);
         requestedTemp.duration.should.equal(30);
     });
 
     it('should limit high temp to 3 * max_daily_basal', function () {
         var profile = { "current_basal":1.0,"max_daily_basal":1.3,"max_basal":10.0 };
-        var requestedTemp = setTempBasal(6, 30, profile, rt);
+        var requestedTemp = tempBasalFunctions.setTempBasal(6, 30, profile, rt);
         requestedTemp.rate.should.equal(3.9);
         requestedTemp.duration.should.equal(30);
     });
 
     it('should limit high temp to 4 * current_basal', function () {
         var profile = { "current_basal":0.7,"max_daily_basal":1.3,"max_basal":10.0 };
-        var requestedTemp = setTempBasal(6, 30, profile, rt);
+        var requestedTemp = tempBasalFunctions.setTempBasal(6, 30, profile, rt);
         requestedTemp.rate.should.equal(2.8);
         requestedTemp.duration.should.equal(30);
     });
+    
     it('should temp to 0 when requested rate is less then 0 * current_basal', function () {
         var profile = { "current_basal":0.7,"max_daily_basal":1.3,"max_basal":10.0 };
-        var requestedTemp = setTempBasal(-1, 30, profile, rt);
+        var requestedTemp = tempBasalFunctions.setTempBasal(-1, 30, profile, rt);
         requestedTemp.rate.should.equal(0);
+        requestedTemp.duration.should.equal(30);
+    });
+
+    it('should limit high temp to 4 * max_daily_basal when overridden', function () {
+        var profile = { "current_basal":2.0,"max_daily_basal":1.3,"max_basal":10.0, "max_daily_safety_multiplier": 4};
+        var requestedTemp = tempBasalFunctions.setTempBasal(6, 30, profile, rt);
+        requestedTemp.rate.should.equal(5.2);
+        requestedTemp.duration.should.equal(30);
+    });
+
+    it('should limit high temp to 5 * current_basal when overridden', function () {
+        var profile = { "current_basal":0.7,"max_daily_basal":1.3,"max_basal":10.0, "current_basal_safety_multiplier": 5};
+        var requestedTemp = tempBasalFunctions.setTempBasal(6, 30, profile, rt);
+        requestedTemp.rate.should.equal(3.5);
         requestedTemp.duration.should.equal(30);
     });
 


### PR DESCRIPTION
* A couple more temp basal IOB tests; lib/iob/history.js is now pretty well covered

* Configurable safety limits pass 1, with tests

* Added --update-preferences and --export-defaults options to oref0-get-profile